### PR TITLE
Extend surface energy module for intermetallics

### DIFF
--- a/examples/surface_thermo_pdin/pdin.cif
+++ b/examples/surface_thermo_pdin/pdin.cif
@@ -1,0 +1,23 @@
+# PdIn - B2 (CsCl-type) structure
+# Space group: Pm-3m (221)
+# Lattice parameter: ~3.25 Angstrom
+
+data_PdIn
+_symmetry_space_group_name_H-M   'P m -3 m'
+_symmetry_Int_Tables_number      221
+_cell_length_a                   3.2500
+_cell_length_b                   3.2500
+_cell_length_c                   3.2500
+_cell_angle_alpha                90.0000
+_cell_angle_beta                 90.0000
+_cell_angle_gamma                90.0000
+
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+Pd1  Pd  0.00000  0.00000  0.00000  1.0
+In1  In  0.50000  0.50000  0.50000  1.0

--- a/examples/surface_thermo_pdin/surface_thermo_intermetallics.py
+++ b/examples/surface_thermo_pdin/surface_thermo_intermetallics.py
@@ -1,0 +1,171 @@
+#!/home/thiagotd/envs/aiida/bin/python
+"""
+Intermetallic Surface Energy Calculation for PdIn (B2 structure)
+
+This script demonstrates the metal_surface_energy module for computing
+surface energies of stoichiometric intermetallics using the simple formula:
+γ = (E_slab - N·E_bulk/atom) / (2A)
+
+Material: PdIn (B2 / CsCl-type structure)
+Surfaces: (110), (100), (111)
+
+This formula is valid for stoichiometric and symmetric surfaces where:
+- The slab composition matches the bulk stoichiometry
+- Both surfaces (top and bottom) are equivalent
+
+Usage:
+    source ~/envs/aiida/bin/activate
+    python surface_thermo_intermetallics.py
+"""
+
+import sys
+import os
+from aiida import load_profile
+from teros.core.metal_surface_energy import build_metal_surface_energy_workgraph
+
+
+def main():
+    """Run surface energy calculation for PdIn intermetallic."""
+
+    print("\n" + "="*70)
+    print("INTERMETALLIC SURFACE ENERGY CALCULATION")
+    print("Material: PdIn (B2 structure)")
+    print("="*70)
+
+    # Load AiiDA profile
+    print("\n1. Loading AiiDA profile...")
+    load_profile(profile='presto')
+    print("   Profile loaded")
+
+    # Setup paths
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    bulk_structure_path = os.path.join(script_dir, 'pdin.cif')
+
+    print(f"\n2. Structure:")
+    print(f"   Bulk:   {bulk_structure_path}")
+
+    # Code configuration - using cluster02
+    code_label = 'VASP-6.5.1@cluster02'
+    potential_family = 'PBE'
+
+    # VASP parameters for intermetallics
+    # Note: ISMEAR=1 (Methfessel-Paxton) is recommended for metals/intermetallics
+    bulk_parameters = {
+        'prec': 'Accurate',
+        'encut': 500,
+        'ediff': 1e-6,
+        'ismear': 1,      # Methfessel-Paxton for metals
+        'sigma': 0.2,     # Smearing width
+        'ibrion': 2,
+        'isif': 3,        # Full relaxation for bulk
+        'nsw': 100,
+        'ediffg': -0.01,
+        'algo': 'Normal',
+        'lreal': 'Auto',
+        'lwave': False,
+        'lcharg': False,
+    }
+
+    # Slab parameters - only relax ionic positions
+    slab_parameters = bulk_parameters.copy()
+    slab_parameters['isif'] = 2  # Fix cell, relax ions
+
+    # Scheduler options for cluster02 (24 cores per machine)
+    common_options = {
+        'resources': {
+            'num_machines': 1,
+            'num_cores_per_machine': 24,
+        },
+    }
+
+    # Surface orientations to study - all in ONE WorkGraph!
+    # For B2 structure, (110) is typically the most stable
+    miller_indices = [
+        [1, 1, 0],  # Most stable for B2
+        [1, 0, 0],  # Second most stable
+        [1, 1, 1],  # Third
+    ]
+
+    print(f"\n3. Miller indices: {miller_indices}")
+    print("   All orientations in a single WorkGraph!")
+
+    print("\n4. Building workgraph...")
+
+    # Build ONE workflow containing all Miller indices
+    wg = build_metal_surface_energy_workgraph(
+        # Structure
+        bulk_structure_path=bulk_structure_path,
+
+        # Code
+        code_label=code_label,
+        potential_family=potential_family,
+        potential_mapping={'Pd': 'Pd', 'In': 'In'},  # Map both elements!
+        kpoints_spacing=0.03,
+        clean_workdir=False,
+
+        # Bulk parameters
+        bulk_parameters=bulk_parameters,
+        bulk_options=common_options,
+
+        # Slab generation - ALL Miller indices!
+        miller_indices=miller_indices,
+        min_slab_thickness=20.0,
+        min_vacuum_thickness=20.0,
+        lll_reduce=True,
+        center_slab=True,
+        symmetrize=True,  # Important for stoichiometric surfaces!
+        primitive=True,
+
+        # Slab relaxation
+        slab_parameters=slab_parameters,
+        slab_options=common_options,
+        slab_kpoints_spacing=0.04,
+
+        # Concurrency control - cluster02 can only run one calculation at a time
+        max_concurrent_jobs=1,
+
+        name='PdIn_surface_energy',
+    )
+
+    print("   WorkGraph built successfully")
+    print(f"   Contains tasks: surface_hkl_110, surface_hkl_100, surface_hkl_111")
+
+    # Submit
+    print("\n5. Submitting to AiiDA daemon...")
+    wg.submit(wait=False)
+
+    print(f"\n{'='*70}")
+    print("WORKFLOW SUBMITTED SUCCESSFULLY")
+    print(f"{'='*70}")
+    print(f"\nWorkGraph PK: {wg.pk}")
+    print(f"\nMonitor with:")
+    print(f"  verdi process status {wg.pk}")
+    print(f"  verdi process show {wg.pk}")
+    print(f"\nExpected outputs per orientation:")
+    print(f"  - bulk_energy, bulk_energy_per_atom, bulk_structure")
+    print(f"  - slab_structures, relaxed_slabs, slab_energies")
+    print(f"  - surface_energies (gamma_eV_A2, gamma_J_m2)")
+    print(f"\nNew intermetallic-specific outputs:")
+    print(f"  - compound_type: 'intermetallic'")
+    print(f"  - formula: 'InPd'")
+    print(f"  - elements: ['In', 'Pd']")
+    print(f"  - composition: bulk composition dict")
+    print(f"  - slab_composition: slab composition dict")
+    print(f"  - is_stoichiometric: True/False")
+    print(f"\nExpected surface energies for PdIn (B2):")
+    print(f"  (110): ~0.5-1.0 J/m2 (typically most stable for B2)")
+    print(f"  (100): ~1.0-1.5 J/m2")
+    print(f"  (111): ~1.5-2.5 J/m2")
+    print(f"{'='*70}\n")
+
+    return wg
+
+
+if __name__ == '__main__':
+    try:
+        wg = main()
+    except Exception as e:
+        print(f"\n Error: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)

--- a/teros/core/metal_surface_energy/__init__.py
+++ b/teros/core/metal_surface_energy/__init__.py
@@ -1,7 +1,8 @@
 """
-Metal Surface Energy Module
+Metal and Intermetallic Surface Energy Module
 
-This module computes surface energies for elemental metals using the simple formula:
+This module computes surface energies for elemental metals and stoichiometric
+intermetallics using the simple formula:
 γ = (E_slab - N·E_bulk/atom) / (2A)
 
 where:
@@ -11,13 +12,19 @@ where:
 - A: Surface area
 - Factor of 2 accounts for two surfaces
 
-This is much simpler than oxide thermodynamics since there are no chemical potential
-dependencies for pure metals.
+Supported materials:
+- Elemental metals: Au, Ag, Cu, Pt, Pd, Ni, Fe, etc.
+- Stoichiometric intermetallics: PdIn, AuCu, NiAl, Cu3Au, etc.
+
+For stoichiometric and symmetric surfaces, no chemical potential dependencies
+are needed. For non-stoichiometric surfaces, use the oxide thermodynamics
+approach instead.
 """
 
 from .surface_energy import (
     calculate_metal_surface_energy,
     compute_metal_surface_energies_scatter,
+    identify_compound_type,
 )
 
 from .workgraph import build_metal_surface_energy_workgraph
@@ -25,5 +32,6 @@ from .workgraph import build_metal_surface_energy_workgraph
 __all__ = [
     'calculate_metal_surface_energy',
     'compute_metal_surface_energies_scatter',
+    'identify_compound_type',
     'build_metal_surface_energy_workgraph',
 ]

--- a/teros/core/metal_surface_energy/surface_energy.py
+++ b/teros/core/metal_surface_energy/surface_energy.py
@@ -1,10 +1,19 @@
 """
-Surface Energy Calculations for Metals.
+Surface Energy Calculations for Metals and Intermetallics.
 
-This module implements the simple surface energy formula for elemental metals:
+This module implements the simple surface energy formula:
 γ = (E_slab - N·E_bulk_atom) / (2A)
 
-No chemical potential dependencies since metals are elemental systems.
+This formula applies to:
+- Elemental metals (Au, Ag, Cu, Pt, etc.)
+- Stoichiometric and symmetric intermetallic surfaces (PdIn, AuCu, NiAl, etc.)
+
+For stoichiometric slabs where the surface composition matches the bulk
+stoichiometry and both surfaces are equivalent (symmetric slab), no chemical
+potential dependencies are needed. The simple formula above is sufficient.
+
+Note: For non-stoichiometric or asymmetric intermetallic surfaces, chemical
+potential-dependent formulations are required (to be implemented separately).
 """
 
 from __future__ import annotations
@@ -19,6 +28,63 @@ from aiida_workgraph import task, dynamic
 # Conversion factor: 1 eV/Ų = 16.0218 J/m²
 EV_PER_A2_TO_J_PER_M2 = 16.0218
 
+
+def identify_compound_type(structure: orm.StructureData) -> dict:
+    """
+    Identify whether a structure is an elemental metal or intermetallic.
+
+    Args:
+        structure: The structure to analyze
+
+    Returns:
+        Dictionary containing:
+        - compound_type: 'elemental' or 'intermetallic'
+        - elements: List of element symbols
+        - composition: Dict mapping element to count
+        - formula: Chemical formula string (e.g., 'Au', 'PdIn', 'Au3Cu')
+        - stoichiometry: Dict mapping element to stoichiometric ratio
+    """
+    ase_atoms = structure.get_ase()
+    symbols = ase_atoms.get_chemical_symbols()
+    composition = dict(Counter(symbols))
+    elements = sorted(composition.keys())
+
+    # Determine compound type
+    if len(elements) == 1:
+        compound_type = 'elemental'
+        formula = elements[0]
+    else:
+        compound_type = 'intermetallic'
+        # Build formula string (e.g., 'PdIn' or 'Au3Cu')
+        # Find GCD to reduce stoichiometry
+        from math import gcd
+        from functools import reduce
+        counts = list(composition.values())
+        common_divisor = reduce(gcd, counts)
+        reduced_counts = {el: composition[el] // common_divisor for el in elements}
+
+        # Build formula
+        formula_parts = []
+        for el in elements:
+            count = reduced_counts[el]
+            if count == 1:
+                formula_parts.append(el)
+            else:
+                formula_parts.append(f'{el}{count}')
+        formula = ''.join(formula_parts)
+
+    # Calculate stoichiometric ratios
+    total_atoms = sum(composition.values())
+    stoichiometry = {el: composition[el] / total_atoms for el in elements}
+
+    return {
+        'compound_type': compound_type,
+        'elements': elements,
+        'composition': composition,
+        'formula': formula,
+        'stoichiometry': stoichiometry,
+    }
+
 @task.calcfunction
 def calculate_metal_surface_energy(
     bulk_structure: orm.StructureData,
@@ -27,16 +93,20 @@ def calculate_metal_surface_energy(
     slab_energy: orm.Float,
 ) -> orm.Dict:
     """
-    Calculate surface energy for a metal slab.
-    
+    Calculate surface energy for a metal or stoichiometric intermetallic slab.
+
     Uses the formula: γ = (E_slab - N_slab·E_bulk/N_bulk) / (2A)
-    
+
+    This formula is valid for:
+    - Elemental metals (Au, Ag, Cu, Pt, etc.)
+    - Stoichiometric and symmetric intermetallic surfaces (PdIn, AuCu, NiAl, etc.)
+
     Args:
         bulk_structure: Bulk crystal structure
         bulk_energy: Total energy of bulk structure (eV)
         slab_structure: Slab structure
         slab_energy: Total energy of slab (eV)
-        
+
     Returns:
         Dictionary containing:
         - gamma_eV_A2: Surface energy in eV/Ų
@@ -46,32 +116,47 @@ def calculate_metal_surface_energy(
         - E_bulk_per_atom_eV: Bulk energy per atom
         - N_slab: Number of atoms in slab
         - N_bulk: Number of atoms in bulk
-        - element: Element symbol
+        - compound_type: 'elemental' or 'intermetallic'
+        - formula: Chemical formula (e.g., 'Au', 'PdIn', 'Au3Cu')
+        - elements: List of element symbols
+        - composition: Dict with element counts in bulk
+        - slab_composition: Dict with element counts in slab
+        - is_stoichiometric: Whether slab has same stoichiometry as bulk
     """
-    # Get bulk info
+    # Get bulk info and composition
     bulk_ase = bulk_structure.get_ase()
     n_bulk = len(bulk_ase)
     E_bulk_per_atom = bulk_energy.value / n_bulk
-    
-    # Get slab info
+    bulk_comp_info = identify_compound_type(bulk_structure)
+
+    # Get slab info and composition
     slab_ase = slab_structure.get_ase()
     n_slab = len(slab_ase)
-    
+    slab_symbols = slab_ase.get_chemical_symbols()
+    slab_composition = dict(Counter(slab_symbols))
+
+    # Check if slab is stoichiometric (same composition ratio as bulk)
+    bulk_stoich = bulk_comp_info['stoichiometry']
+    slab_total = sum(slab_composition.values())
+    slab_stoich = {el: slab_composition.get(el, 0) / slab_total for el in bulk_comp_info['elements']}
+
+    # Compare stoichiometries (with small tolerance for numerical precision)
+    is_stoichiometric = all(
+        abs(bulk_stoich.get(el, 0) - slab_stoich.get(el, 0)) < 0.01
+        for el in set(list(bulk_stoich.keys()) + list(slab_stoich.keys()))
+    )
+
     # Calculate surface area from cell vectors (a × b)
     cell = slab_ase.get_cell()
     a_vec = cell[0]
     b_vec = cell[1]
     cross = np.cross(a_vec, b_vec)
     area_A2 = float(np.linalg.norm(cross))
-    
+
     # Calculate surface energy: γ = (E_slab - N·E_bulk/atom) / (2A)
     gamma_eV_A2 = (slab_energy.value - n_slab * E_bulk_per_atom) / (2 * area_A2)
     gamma_J_m2 = gamma_eV_A2 * EV_PER_A2_TO_J_PER_M2
-    
-    # Get element (for single-element metals)
-    symbols = set(bulk_ase.get_chemical_symbols())
-    element = list(symbols)[0] if len(symbols) == 1 else ','.join(sorted(symbols))
-    
+
     return orm.Dict(dict={
         'gamma_eV_A2': float(gamma_eV_A2),
         'gamma_J_m2': float(gamma_J_m2),
@@ -80,7 +165,12 @@ def calculate_metal_surface_energy(
         'E_bulk_per_atom_eV': float(E_bulk_per_atom),
         'N_slab': int(n_slab),
         'N_bulk': int(n_bulk),
-        'element': element,
+        'compound_type': bulk_comp_info['compound_type'],
+        'formula': bulk_comp_info['formula'],
+        'elements': bulk_comp_info['elements'],
+        'composition': bulk_comp_info['composition'],
+        'slab_composition': slab_composition,
+        'is_stoichiometric': is_stoichiometric,
     })
 
 

--- a/teros/core/metal_surface_energy/workgraph.py
+++ b/teros/core/metal_surface_energy/workgraph.py
@@ -1,12 +1,19 @@
 """
-Metal Surface Energy WorkGraph Builder.
+Metal and Intermetallic Surface Energy WorkGraph Builder.
 
 This module provides the main workflow builder for computing surface energies
-of elemental metals. It supports:
+of elemental metals and stoichiometric intermetallics. It supports:
 - Multiple Miller indices in a single parent workflow
 - Single bulk calculation shared across all orientations
 - Multiple terminations per orientation
 - Bulk relaxation → Slab generation → Slab relaxation → Surface energy calculation
+
+Supported materials:
+- Elemental metals: Au, Ag, Cu, Pt, Pd, Ni, Fe, etc.
+- Stoichiometric intermetallics: PdIn, AuCu, NiAl, Cu3Au, etc.
+
+For stoichiometric and symmetric intermetallic surfaces, the simple formula
+γ = (E_slab - N·E_bulk/atom) / (2A) is used, same as for elemental metals.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
…allics

Add support for calculating surface energies of stoichiometric and symmetric intermetallic surfaces (PdIn, AuCu, NiAl, etc.) using the same simple formula as elemental metals: γ = (E_slab - N·E_bulk/atom) / (2A)

Changes:
- Add identify_compound_type() function to detect elemental vs intermetallic
- Update calculate_metal_surface_energy() with composition analysis
- Add is_stoichiometric flag to validate slab composition
- Include detailed composition info in output (formula, elements, etc.)
- Update documentation and README for intermetallics usage
- Add PdIn (B2 structure) example in examples/surface_thermo_pdin/